### PR TITLE
Update ice_breaker.py to support mock gist call for linked in.

### DIFF
--- a/agents/linkedin_lookup_agent.py
+++ b/agents/linkedin_lookup_agent.py
@@ -15,7 +15,7 @@ from tools.tools import get_profile_url_tavily
 def lookup(name: str) -> str:
     llm = ChatOpenAI(
         temperature=0,
-        model_name="gpt-3.5-turbo",
+        model_name="gpt-4o-mini",
     )
     template = """given the full name {name_of_person} I want you to get it me a link to their Linkedin profile page.
                               Your answer should contain only a URL"""

--- a/ice_breaker.py
+++ b/ice_breaker.py
@@ -8,7 +8,12 @@ from agents.linkedin_lookup_agent import lookup as linkedin_lookup_agent
 
 def ice_break_with(name: str) -> str:
     linkedin_username = linkedin_lookup_agent(name=name)
-    linkedin_data = scrape_linkedin_profile(linkedin_profile_url=linkedin_username)
+    # This will only work if you provide nubela PROXYCURL_API_KEY
+    # linkedin_data = scrape_linkedin_profile(linkedin_profile_url=linkedin_username)
+    
+    # Use the mock=True flag you want to use gist 
+    linkedin_data = scrape_linkedin_profile(linkedin_profile_url=linkedin_username, mock=True)
+
 
     summary_template = """
     given the Linkedin information {information} about a person I want you to create:

--- a/tools/tools.py
+++ b/tools/tools.py
@@ -5,4 +5,4 @@ def get_profile_url_tavily(name: str):
     """Searches for Linkedin or Twitter Profile Page."""
     search = TavilySearchResults()
     res = search.run(f"{name}")
-    return res[0]["url"]
+    return res


### PR DESCRIPTION
Added support for the gist mock support.  the code that was provided in the 2-search-agent-finish was failing since I do not have access ProxyCurl.  I updated it to the use gist via the mock=true flag and it finally worked.  It took a bit to figure out since the error message wasn't that clear.